### PR TITLE
feat: add CipherMate label to modal

### DIFF
--- a/modal.css
+++ b/modal.css
@@ -95,4 +95,5 @@
 .ciphermate-text {
   font-size: 0.875rem;
   color: #8b949e;
+  font-family: 'Titillium Web', sans-serif;
 }

--- a/modal.css
+++ b/modal.css
@@ -91,3 +91,8 @@
   line-height: 1;
   padding: 0.25rem 0.5rem;
 }
+
+.ciphermate-text {
+  font-size: 0.875rem;
+  color: #8b949e;
+}

--- a/modal.html
+++ b/modal.html
@@ -1,3 +1,7 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700&display=swap" rel="stylesheet">
+
 <div class="modal-card position-fixed top-0 end-0 p-3 mt-3 me-3">
   <div class="position-relative mb-3 modal-field">
     <textarea id="input-text" class="form-control pe-5" placeholder="Enter text"></textarea>

--- a/modal.html
+++ b/modal.html
@@ -20,9 +20,12 @@
   <div class="position-relative mb-3">
     <input id="key-input" type="text" class="form-control pe-5" placeholder="Key" />
   </div>
-  <div class="d-flex gap-2 justify-content-end mt-auto">
-    <button class="btn btn-primary encrypt-btn">Encrypt</button>
-    <button class="btn btn-success decrypt-btn">Decrypt</button>
-    <button class="btn btn-outline-secondary close-btn">Close</button>
+  <div class="d-flex justify-content-between align-items-center mt-auto">
+    <span class="ciphermate-text">CipherMate</span>
+    <div class="d-flex gap-2">
+      <button class="btn btn-primary encrypt-btn">Encrypt</button>
+      <button class="btn btn-success decrypt-btn">Decrypt</button>
+      <button class="btn btn-outline-secondary close-btn">Close</button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- display a "CipherMate" label beside the action buttons in the modal
- style label to match existing design

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689598dea8a48327aa7b9702481466f2