### PR TITLE
Add CipherMate branding to modal

### DIFF
--- a/modal.css
+++ b/modal.css
@@ -1,3 +1,10 @@
+@font-face {
+  font-family: 'Titillium Web';
+  src: url('fonts/TitilliumWeb-Regular.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
 .modal-card {
   z-index: 10000;
   width: min(600px, 90vw);
@@ -90,4 +97,8 @@
 .copy-btn {
   line-height: 1;
   padding: 0.25rem 0.5rem;
+}
+
+.ciphermate-text {
+  font-family: 'Titillium Web', sans-serif;
 }

--- a/modal.html
+++ b/modal.html
@@ -20,9 +20,12 @@
   <div class="position-relative mb-3">
     <input id="key-input" type="text" class="form-control pe-5" placeholder="Key" />
   </div>
-  <div class="d-flex gap-2 justify-content-end mt-auto">
-    <button class="btn btn-primary encrypt-btn">Encrypt</button>
-    <button class="btn btn-success decrypt-btn">Decrypt</button>
-    <button class="btn btn-outline-secondary close-btn">Close</button>
+  <div class="d-flex justify-content-between align-items-center mt-auto">
+    <span class="ciphermate-text">CipherMate</span>
+    <div class="d-flex gap-2">
+      <button class="btn btn-primary encrypt-btn">Encrypt</button>
+      <button class="btn btn-success decrypt-btn">Decrypt</button>
+      <button class="btn btn-outline-secondary close-btn">Close</button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add 'CipherMate' label alongside action buttons
- Load Titillium Web font and style label accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68959cc382488327b88c484bcf21f04f