### PR TITLE
Add CipherMate branding to modal

### DIFF
--- a/modal.html
+++ b/modal.html
@@ -20,7 +20,8 @@
   <div class="position-relative mb-3">
     <input id="key-input" type="text" class="form-control pe-5" placeholder="Key" />
   </div>
-  <div class="d-flex gap-2 justify-content-end mt-auto">
+  <div class="d-flex gap-2 align-items-center mt-auto">
+    <span class="me-auto">CipherMate</span>
     <button class="btn btn-primary encrypt-btn">Encrypt</button>
     <button class="btn btn-success decrypt-btn">Decrypt</button>
     <button class="btn btn-outline-secondary close-btn">Close</button>


### PR DESCRIPTION
## Summary
- Display "CipherMate" text at the bottom-left of the modal alongside the action buttons.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68959e4449408327ba95298d59467f67