### PR TITLE
docs: add inline documentation

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,12 @@
+/**
+ * Service worker entry point.
+ *
+ * When the extension's action icon is clicked, this script injects the
+ * content script (`content.js`) into the active tab. The content script then
+ * handles rendering the encryption/decryption modal in the page context.
+ */
 chrome.action.onClicked.addListener(tab => {
+  // Execute the content script in the context of the current tab
   chrome.scripting.executeScript({
     target: { tabId: tab.id },
     files: ['content.js'],

--- a/content.js
+++ b/content.js
@@ -1,6 +1,13 @@
+/**
+ * Content script injected into the active tab. It renders a self-contained
+ * Shadow DOM modal that allows the user to encrypt or decrypt arbitrary text
+ * using a shared key. All crypto operations run locally via the Web Crypto API.
+ */
 (async () => {
+  // Avoid injecting multiple overlays if the content script runs again
   if (document.getElementById('sample-extension-overlay')) return;
 
+  // Load and register the custom font used within the modal
   const font = new FontFace(
     'Titillium Web',
     `url('${chrome.runtime.getURL('fonts/TitilliumWeb-Regular.ttf')}')`
@@ -8,10 +15,12 @@
   await font.load();
   document.fonts.add(font);
 
+  // Create a host element and attach a Shadow DOM for style isolation
   const overlayHost = document.createElement('div');
   overlayHost.id = 'sample-extension-overlay';
   const shadow = overlayHost.attachShadow({ mode: 'open' });
 
+  /** Inject a stylesheet link into the shadow root. */
   const addStyle = href => {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
@@ -21,17 +30,20 @@
   addStyle('https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css');
   addStyle(chrome.runtime.getURL('modal.css'));
 
+  // Load the modal markup and append it to the shadow root
   const html = await (await fetch(chrome.runtime.getURL('modal.html'))).text();
   const wrapper = document.createElement('div');
   wrapper.innerHTML = html.trim();
   const overlay = wrapper.firstElementChild;
   shadow.appendChild(overlay);
 
+  // Shorthand to lookup elements inside the shadow DOM
   const $ = id => shadow.getElementById(id);
   const inputEl = $('input-text');
   const outputEl = $('output-text');
   const keyEl = $('key-input');
 
+  // Wire up clipboard copy buttons for each field
   shadow.querySelectorAll('.copy-btn').forEach(btn => {
     const target = $(btn.dataset.target);
     btn.addEventListener('click', async () => {
@@ -52,6 +64,10 @@
     });
   });
 
+  /**
+   * Import a string as a 16-byte AES-CBC key.
+   * Only the first 16 bytes of the provided string are used.
+   */
   const importKey = keyStr => {
     const keyBytes = new TextEncoder().encode(keyStr).slice(0, 16);
     const keyBuffer = new Uint8Array(16);
@@ -62,9 +78,16 @@
     ]);
   };
 
+  /** Convert an ArrayBuffer to a base64 string. */
   const bufferToBase64 = buffer => btoa(String.fromCharCode(...new Uint8Array(buffer)));
+
+  /** Convert a base64 string back into a Uint8Array buffer. */
   const base64ToBuffer = base64 => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
 
+  /**
+   * Encrypt text with the supplied key.
+   * Returns base64 encoded IV + ciphertext.
+   */
   const encryptText = async (text, keyStr) => {
     const key = await importKey(keyStr);
     const iv = crypto.getRandomValues(new Uint8Array(16));
@@ -79,6 +102,7 @@
     return bufferToBase64(combined);
   };
 
+  /** Decrypt previously encrypted text using the supplied key. */
   const decryptText = async (cipherText, keyStr) => {
     const data = base64ToBuffer(cipherText);
     const iv = data.slice(0, 16);
@@ -92,6 +116,10 @@
     return new TextDecoder().decode(decrypted);
   };
 
+  /**
+   * Higher-order function returning an event handler that processes the input
+   * using the provided crypto function (encrypt or decrypt).
+   */
   const handleCrypto = fn => async () => {
     if (!keyEl.value) {
       outputEl.value = 'Key required';
@@ -104,10 +132,18 @@
     }
   };
 
-  shadow.querySelector('.encrypt-btn').addEventListener('click', handleCrypto(encryptText));
-  shadow.querySelector('.decrypt-btn').addEventListener('click', handleCrypto(decryptText));
-  shadow.querySelector('.close-btn').addEventListener('click', () => overlayHost.remove());
+  // Hook up button actions within the modal
+  shadow
+    .querySelector('.encrypt-btn')
+    .addEventListener('click', handleCrypto(encryptText));
+  shadow
+    .querySelector('.decrypt-btn')
+    .addEventListener('click', handleCrypto(decryptText));
+  shadow
+    .querySelector('.close-btn')
+    .addEventListener('click', () => overlayHost.remove());
 
+  // Finally, inject the shadow host into the page
   document.body.appendChild(overlayHost);
 })();
 

--- a/modal.css
+++ b/modal.css
@@ -1,4 +1,5 @@
 .modal-card {
+  /* Container for the floating modal */
   z-index: 10000;
   width: min(600px, 90vw);
   height: min(400px, 80vh);
@@ -12,6 +13,7 @@
 }
 
 .form-control {
+  /* Shared styling for inputs and textareas */
   border: 1px solid #30363d;
   border-radius: 0.375rem;
   background-color: #0d1117;
@@ -22,6 +24,7 @@
 }
 
 .form-control:focus {
+  /* Highlight active form controls */
   color: #c9d1d9;
   background-color: #0d1117;
   border-color: #58a6ff;
@@ -32,7 +35,6 @@
   color: #8b949e;
   opacity: 1;
 }
-
 
 /* ensure text areas grow to fill available space */
 .modal-field {
@@ -47,6 +49,7 @@
 }
 
 .btn {
+  /* Base button style matching GitHub's dark theme */
   border-radius: 0.375rem;
   background-color: #21262d;
   border: 1px solid #30363d;
@@ -58,6 +61,7 @@
 }
 
 .btn-success {
+  /* Decrypt button */
   background-color: #238636;
   border-color: #2ea043;
   color: #fff;
@@ -68,6 +72,7 @@
 }
 
 .btn-primary {
+  /* Encrypt button */
   background-color: #1f6feb;
   border-color: #388bfd;
   color: #fff;
@@ -78,6 +83,7 @@
 }
 
 .btn-outline-secondary {
+  /* Close button */
   background-color: transparent;
   border: 1px solid #30363d;
   color: #c9d1d9;
@@ -88,11 +94,13 @@
 }
 
 .copy-btn {
+  /* Small clipboard icon buttons */
   line-height: 1;
   padding: 0.25rem 0.5rem;
 }
 
 .ciphermate-text {
+  /* Logo text styling */
   font-family: "Titillium Web", sans-serif;
   font-size: 1.25rem;
 }

--- a/modal.html
+++ b/modal.html
@@ -1,4 +1,5 @@
 <div class="modal-card position-fixed top-0 end-0 p-3 mt-3 me-3">
+  <!-- Text input that users want to encrypt or decrypt -->
   <div class="position-relative mb-3 modal-field">
     <textarea id="input-text" class="form-control pe-5" placeholder="Enter text"></textarea>
     <button
@@ -8,6 +9,8 @@
       title="Copy"
     >📋</button>
   </div>
+
+  <!-- Area where results are displayed -->
   <div class="position-relative mb-3 modal-field">
     <textarea id="output-text" class="form-control pe-5" placeholder="Output text" readonly></textarea>
     <button
@@ -17,9 +20,13 @@
       title="Copy"
     >📋</button>
   </div>
+
+  <!-- Shared secret used for encryption/decryption -->
   <div class="position-relative mb-3">
     <input id="key-input" type="text" class="form-control pe-5" placeholder="Key" />
   </div>
+
+  <!-- Footer with app name and action buttons -->
   <div class="d-flex gap-2 align-items-center mt-auto">
     <span class="me-auto ciphermate-text">CipherMate</span>
     <button class="btn btn-primary encrypt-btn">Encrypt</button>


### PR DESCRIPTION
## Summary
- document background service worker behavior when extension icon is clicked
- expand content script with comments for modal setup and crypto helpers
- annotate modal markup and styles with descriptive comments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689648fa2134832788cb2a032168f987